### PR TITLE
Default context none

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 0.3 (2015-12-12)
 ================
 
+- When using ``request.find_service`` during or before traversal the
+  ``request.context`` is not valid. In these situations the ``context``
+  parameter will default to ``None`` instead of raising an exception.
+  See https://github.com/mmerickel/pyramid_services/pull/8
+
 - Add ``config.find_service_factory`` and ``request.find_service_factory``.
   See https://github.com/mmerickel/pyramid_services/pull/4
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,9 @@ After registering services with the ``Configurator``, they are now
 accessible from the ``request`` object during a request lifecycle via the
 ``request.find_service(iface=Interface, context=_marker, name='')``
 method. Unless a custom ``context`` is passed to ``find_service``, the
-lookup will default to using ``request.context``.
+lookup will default to using ``request.context``. The ``context`` will default
+to ``None`` if a service is searched for during or before traversal in Pyramid
+when there may not be a ``request.context``.
 
 .. code-block:: python
 

--- a/pyramid_services/__init__.py
+++ b/pyramid_services/__init__.py
@@ -92,7 +92,7 @@ def register_service_factory(
 
 def find_service(request, iface=Interface, context=_marker, name=''):
     if context is _marker:
-        context = request.context
+        context = getattr(request, 'context', None)
 
     context_iface = providedBy(context)
     svc_types = (IServiceClassifier, context_iface)

--- a/pyramid_services/tests/test_it.py
+++ b/pyramid_services/tests/test_it.py
@@ -237,6 +237,25 @@ class TestIntegration_register_service_factory(unittest.TestCase):
         self.assertEqual(intr["context"], IFooService)
         self.assertEqual(intr["type"], IBarService)
 
+    def test_with_no_context(self):
+        config = self.config
+        config.register_service_factory(
+            DummyServiceFactory('foo'), IFooService)
+        config.add_view(DummyView(), context=Root, renderer='string')
+
+        called = [False]
+        def factory(request):
+            called[0] = True
+            svc = request.find_service(IFooService)
+            self.assertEqual(svc.result, 'foo')
+            return Root()
+        config.set_root_factory(factory)
+
+        app = self._makeApp()
+        resp = app.get('/')
+        self.assertEqual(resp.body, b'foo')
+        self.assertEqual(called, [True])
+
 class TestIntegration_find_service_factory(unittest.TestCase):
     def setUp(self):
         self.config = pyramid.testing.setUp()


### PR DESCRIPTION
When using `request.find_service` during traversal (in a route factory, for example) this would fail unless you specifically passed a `context=`. This is still possible but will now default to `context=None` instead of raising an exception.

ping @bertjwregeer 
