### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 matrix:
     include:
-        - python: 2.6
-          env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
         - python: 3.3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
-    py26,py27,py33,py34,py35,pypy,pypy3,
+    py27,py33,py34,py35,pypy,pypy3,
     {py2,py3}-cover,coverage
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
 # to defaults for others.
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
